### PR TITLE
Standardize Unit 4-5 math and currency format

### DIFF
--- a/ECO-2251/Assignments/Spring-2025/Nguyen-Tai-Vuong/Assignments/ECO-2251_assignment_UNIT-4_Spring-2025_Nguyen-Tai-Vuong.md
+++ b/ECO-2251/Assignments/Spring-2025/Nguyen-Tai-Vuong/Assignments/ECO-2251_assignment_UNIT-4_Spring-2025_Nguyen-Tai-Vuong.md
@@ -43,7 +43,7 @@ h. If the government spending multiplier decreases from 5 to 4, this means that 
 **Problem 4:**
 
 The data of goods market in an open economy as follows:  
-Consumption function: $C = 250 + 0.6 (Y – T)$  
+Consumption function: $C = 250 + 0.6(Y - T)$  
 Investment function: $I = 300$  
 Government Spending: $G = 250;$  
 Net tax function $(= To + tY)$: $T = 40 + 0,1Y$  

--- a/ECO-2251/Assignments/Spring-2025/Nguyen-Tai-Vuong/Assignments/ECO-2251_assignment_UNIT-5_Spring-2025_Nguyen-Tai-Vuong.md
+++ b/ECO-2251/Assignments/Spring-2025/Nguyen-Tai-Vuong/Assignments/ECO-2251_assignment_UNIT-5_Spring-2025_Nguyen-Tai-Vuong.md
@@ -1,6 +1,6 @@
 **Problem 1**
 
-Suppose the Central Bank buys $5000 bonds from Bình. In return for the Bonds it gives Bình a check for $5000. Suppose Bình’s bank accout is in Bank A, and the required reserve ratio for all banks is 20%. Assume there are no currency drains in this problem and that banks do not hold excess reserves.
+Suppose the Central Bank buys \$5,000 bonds from Bình. In return for the bonds, it gives Bình a check for \$5,000. Suppose Bình’s bank accout is in Bank A, and the required reserve ratio for all banks is 20%. Assume there are no currency drains in this problem and that banks do not hold excess reserves.
 
 a. What will be the change on the balance sheet of Bank A?  
 b. What is the total change in required reserves and excess reserves on the balance sheet of Bank A?  
@@ -8,16 +8,17 @@ c. Suppose Bank A lends out all their excess reserve to Giang. What will be the 
 d. Suppose that Giang deposits the loan in Bank B, and Bank B again loans out all its excess reserve from Giang’s deposit to Phúc. Again, what will be the amount of the loan? What will be the change on the balance sheet of Bank B?  
 e. If this process repeats itself again and again (i.e. Phúc deposits all his money in Bank C and Bank C loans out all its excesss reserve from Phúc’s deposit to say, Quỳnh, etc), we need to know the money multiplier. Write out a formula for the money multiplier in terms of the requied reserve ratio.  
 f. How much will the money supply increase/decrease in the economy due to this purchase of bonds by the Central Bank?  
-g. Suppose that instead of having an requied reserve ratio of 20%, the government wants to use a purchase of $5000 worth of bonds to reach an overall increase in the money supply of $35,000. What will be the required reserve ratio need to be in order to reach that goal?  
-h. Finally, suppose that the same goal ($35,000) is to be achieved, but this time the required reserve ratio is fixed at 20%. How many bonds will the government need to purchase in order to reach their goal?  
+g. Suppose that instead of having an requied reserve ratio of 20%, the government wants to use a purchase of \$5,000 worth of bonds to reach an overall increase in the money supply of \$35,000. What will be the required reserve ratio need to be in order to reach that goal?  
+h. Finally, suppose that the same goal (\$35,000) is to be achieved, but this time the required reserve ratio is fixed at 20%. How many bonds will the government need to purchase in order to reach their goal?  
 
 **Problem 2**
 
-According to the Board of Governors in August 20XX, reserves equaled $44 billion, currency in circulation equaled $777 billion, and checking deposits were $300 billion. What was the money multiplier?
+According to the Board of Governors in August 20XX, reserves equaled \$44 billion, currency in circulation equaled \$777 billion, and checking deposits were \$300 billion. What was the money multiplier?
 
 **Problem 3**
 
-Money Demand: $\text{M}^\text{D} = 0.2\text{Y} – 2000\text{r}$; Nominal Income: Y = $2000
+Money Demand: $M^D = 0.2Y - 2000r$  
+Nominal Income: $Y = 2000$
 
 Money Supply: $\text{M}^\text{S} = 300$
 


### PR DESCRIPTION
Clean up notation in ECO-2251 Unit 4 and Unit 5 assignment files by normalizing equation spacing/symbols and escaping dollar amounts for correct Markdown rendering. This improves readability and prevents currency values from being misinterpreted as inline math delimiters.